### PR TITLE
Back button goes to Dashboard Hub from webhook list

### DIFF
--- a/packages/app-webhooks/src/pages/ListPage.tsx
+++ b/packages/app-webhooks/src/pages/ListPage.tsx
@@ -47,7 +47,8 @@ function ListPage(): JSX.Element {
       title='Webhooks'
       mode={settings.mode}
       onGoBack={() => {
-        window.location.href = dashboardUrl != null ? dashboardUrl : '/'
+        window.location.href =
+          dashboardUrl != null ? `${dashboardUrl}/hub` : '/'
       }}
     >
       <ListWebhookProvider sdkClient={sdkClient} pageSize={25}>


### PR DESCRIPTION
### What does this PR do?
Add /hub URL segment to list page back button