### PR TITLE
Add `canUser` permission checks

### DIFF
--- a/packages/app-webhooks/src/components/Details/WebhookCircuit.tsx
+++ b/packages/app-webhooks/src/components/Details/WebhookCircuit.tsx
@@ -1,6 +1,7 @@
 import { appRoutes } from '#data/routes'
 import { EventCallbacksTable } from '#components/Common/EventCallbacksTable'
 import {
+  useTokenProvider,
   A,
   Badge,
   Button,
@@ -13,12 +14,17 @@ import { useLocation } from 'wouter'
 import { useWebhookDetailsContext } from './Provider'
 
 export function WebhookCircuit(): JSX.Element | null {
+  const { canUser } = useTokenProvider()
   const {
     state: { data },
     resetWebhookCircuit
   } = useWebhookDetailsContext()
 
-  if (data == null || data.last_event_callbacks === undefined) {
+  if (
+    data == null ||
+    data.last_event_callbacks === undefined ||
+    !canUser('read', 'event_callbacks')
+  ) {
     return null
   }
 

--- a/packages/app-webhooks/src/pages/DeleteWebhookPage.tsx
+++ b/packages/app-webhooks/src/pages/DeleteWebhookPage.tsx
@@ -4,22 +4,41 @@ import { appRoutes } from '#data/routes'
 import {
   useTokenProvider,
   useCoreSdkProvider,
+  Button,
+  EmptyState,
   PageSkeleton,
   PageLayout
 } from '@commercelayer/core-app-elements'
-import { useLocation, useRoute } from 'wouter'
+import { Link, useLocation, useRoute } from 'wouter'
 import { WebhookRemoval } from '#components/Delete/WebhookRemoval'
 
 const DeleteWebhookPage = (): JSX.Element | null => {
-  const { settings } = useTokenProvider()
+  const { settings, canUser } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const [_match, params] = useRoute(appRoutes.deleteWebhook.path)
   const [_, setLocation] = useLocation()
 
   const webhookId = params == null ? null : params.webhookId
 
-  if (webhookId == null) {
-    return null
+  if (webhookId == null || !canUser('destroy', 'webhooks')) {
+    return (
+      <PageLayout
+        title='Delete webhook'
+        onGoBack={() => {
+          setLocation(appRoutes.list.makePath())
+        }}
+        mode={settings.mode}
+      >
+        <EmptyState
+          title='Not authorized'
+          action={
+            <Link href={appRoutes.list.makePath()}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
   }
 
   if (sdkClient == null) {

--- a/packages/app-webhooks/src/pages/EditWebhookPage.tsx
+++ b/packages/app-webhooks/src/pages/EditWebhookPage.tsx
@@ -3,23 +3,42 @@ import { ErrorNotFound } from '#components/ErrorNotFound'
 import { appRoutes } from '#data/routes'
 import {
   useCoreSdkProvider,
+  Button,
+  EmptyState,
   PageSkeleton,
   PageLayout,
   useTokenProvider
 } from '@commercelayer/core-app-elements'
-import { useLocation, useRoute } from 'wouter'
+import { Link, useLocation, useRoute } from 'wouter'
 import WebhookForm from '#components/Form/WebhookForm'
 
 const EditWebhookPage = (): JSX.Element | null => {
-  const { settings } = useTokenProvider()
+  const { settings, canUser } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const [_match, params] = useRoute(appRoutes.editWebhook.path)
   const [_location, setLocation] = useLocation()
 
   const webhookId = params == null ? null : params.webhookId
 
-  if (webhookId == null) {
-    return null
+  if (webhookId == null || !canUser('update', 'webhooks')) {
+    return (
+      <PageLayout
+        title='Edit webhook'
+        onGoBack={() => {
+          setLocation(appRoutes.list.makePath())
+        }}
+        mode={settings.mode}
+      >
+        <EmptyState
+          title='Not authorized'
+          action={
+            <Link href={appRoutes.list.makePath()}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
   }
 
   if (sdkClient == null) {

--- a/packages/app-webhooks/src/pages/EventCallbacksPage.tsx
+++ b/packages/app-webhooks/src/pages/EventCallbacksPage.tsx
@@ -1,23 +1,49 @@
 import { appRoutes } from '#data/routes'
-import { useRoute, useLocation } from 'wouter'
+import { Link, useRoute, useLocation } from 'wouter'
 import { ListEventCallbackProvider } from '#components/EventCallbacks/Provider'
 import {
-  PageSkeleton,
-  PageLayout,
-  List,
-  EmptyState,
   useCoreSdkProvider,
-  useTokenProvider
+  useTokenProvider,
+  Button,
+  EmptyState,
+  List,
+  PageLayout,
+  PageSkeleton
 } from '@commercelayer/core-app-elements'
 import { EventCallbacksTable } from '#components/Common/EventCallbacksTable'
 
 function EventCallbacksPage(): JSX.Element {
-  const { settings } = useTokenProvider()
+  const { settings, canUser } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const [_location, setLocation] = useLocation()
   const [_match, params] = useRoute(appRoutes.webhookEventCallbacks.path)
 
   const webhookId = params == null ? null : params.webhookId
+
+  if (
+    webhookId == null ||
+    !canUser('read', 'webhooks') ||
+    !canUser('read', 'event_callbacks')
+  ) {
+    return (
+      <PageLayout
+        title='Event callbacks'
+        onGoBack={() => {
+          setLocation(appRoutes.list.makePath())
+        }}
+        mode={settings.mode}
+      >
+        <EmptyState
+          title='Not authorized'
+          action={
+            <Link href={appRoutes.list.makePath()}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
+  }
 
   if (sdkClient == null) {
     console.warn('Waiting for SDK client')
@@ -29,7 +55,7 @@ function EventCallbacksPage(): JSX.Element {
       title='Event Callbacks'
       mode={settings.mode}
       onGoBack={() => {
-        setLocation(appRoutes.details.makePath(webhookId as string))
+        setLocation(appRoutes.details.makePath(webhookId))
       }}
     >
       <ListEventCallbackProvider

--- a/packages/app-webhooks/src/pages/ListPage.tsx
+++ b/packages/app-webhooks/src/pages/ListPage.tsx
@@ -32,7 +32,7 @@ function getListUiStatus(webhook: Webhook): StatusUI {
 }
 
 function ListPage(): JSX.Element {
-  const { settings } = useTokenProvider()
+  const { settings, canUser } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const { dashboardUrl } = useTokenProvider()
   const [_location, setLocation] = useLocation()
@@ -40,6 +40,20 @@ function ListPage(): JSX.Element {
   if (sdkClient == null) {
     console.warn('Waiting for SDK client')
     return <PageSkeleton />
+  }
+
+  if (!canUser('read', 'webhooks')) {
+    return (
+      <PageLayout
+        title='Webhooks'
+        mode={settings.mode}
+        onGoBack={() => {
+          setLocation(appRoutes.list.makePath())
+        }}
+      >
+        <EmptyState title='You are not authorized' />
+      </PageLayout>
+    )
   }
 
   return (
@@ -69,9 +83,11 @@ function ListPage(): JSX.Element {
                 title='No webhook yet!'
                 description='Create your first webhook'
                 action={
-                  <Link href={appRoutes.newWebhook.makePath()}>
-                    <Button variant='primary'>New webhook</Button>
-                  </Link>
+                  canUser('create', 'webhooks') ? (
+                    <Link href={appRoutes.newWebhook.makePath()}>
+                      <Button variant='primary'>New webhook</Button>
+                    </Link>
+                  ) : undefined
                 }
               />
             )
@@ -85,9 +101,11 @@ function ListPage(): JSX.Element {
               isDisabled={isRefetching}
               title='All webhooks'
               actionButton={
-                <Link href={appRoutes.newWebhook.makePath()}>
-                  <A>New webhook</A>
-                </Link>
+                canUser('create', 'webhooks') ? (
+                  <Link href={appRoutes.newWebhook.makePath()}>
+                    <A>New webhook</A>
+                  </Link>
+                ) : undefined
               }
               pagination={{
                 recordsPerPage,

--- a/packages/app-webhooks/src/pages/NewWebhookPage.tsx
+++ b/packages/app-webhooks/src/pages/NewWebhookPage.tsx
@@ -1,15 +1,17 @@
 import { appRoutes } from '#data/routes'
 import {
   useCoreSdkProvider,
+  Button,
+  EmptyState,
   PageSkeleton,
   PageLayout,
   useTokenProvider
 } from '@commercelayer/core-app-elements'
-import { useLocation, useRoute } from 'wouter'
+import { Link, useLocation, useRoute } from 'wouter'
 import WebhookForm from '#components/Form/WebhookForm'
 
 const NewWebhookPage = (): JSX.Element | null => {
-  const { settings } = useTokenProvider()
+  const { settings, canUser } = useTokenProvider()
   const { sdkClient } = useCoreSdkProvider()
   const [_match] = useRoute(appRoutes.newWebhook.path)
   const [_location, setLocation] = useLocation()
@@ -17,6 +19,27 @@ const NewWebhookPage = (): JSX.Element | null => {
   if (sdkClient == null) {
     console.warn('Waiting for SDK client')
     return <PageSkeleton hasHeaderDescription />
+  }
+
+  if (!canUser('create', 'webhooks')) {
+    return (
+      <PageLayout
+        title='New webhook'
+        mode={settings.mode}
+        onGoBack={() => {
+          setLocation(appRoutes.list.makePath())
+        }}
+      >
+        <EmptyState
+          title='You are not authorized'
+          action={
+            <Link href={appRoutes.list.makePath()}>
+              <Button variant='primary'>Go back</Button>
+            </Link>
+          }
+        />
+      </PageLayout>
+    )
   }
 
   return (


### PR DESCRIPTION
### What does this PR do?
Add `canUser` permission checks in all pages of webhooks application.

### Description of Task to be completed
- `History` page is filled with a 'You are not authorized' empty state if `!canUser('read', 'webhooks')`
- `New webhook` buttons of `history page` are shown if `canUser('create', 'webhooks')`
- `New webhook` page is filled with a 'You are not authorized' empty state if `!canUser('create', 'webhooks')`
- `Webhook detail` page is filled with a 'You are not authorized' empty state if `!canUser('read', 'webhooks')`
- Contextual menu of `webhook detail` page is filled by `Edit` and/or `Delete` menu items if respectively `canUser('update', 'webhooks')` and/or `canUser('destroy', 'webhooks')`. The menu separator is shown only if both the conditions are `true`
- Event callbacks card of `webhook detail` page is hidden if `!canUser('read', 'event_callbacks')`
- `Event callbacks` page is filled with a 'You are not authorized' empty state if `!canUser('read', 'event_callbacks')`
- `Edit webhook` page is filled with a 'You are not authorized' empty state if `!canUser('update', 'webhooks')`
- `Delete webhook` page is filled with a 'You are not authorized' empty state if `!canUser('destroy', 'webhooks')`

Closes #4 