### PR TITLE
Add `vite-tsconfig-paths` `Vite` plugin

### DIFF
--- a/packages/app-webhooks/package.json
+++ b/packages/app-webhooks/package.json
@@ -50,6 +50,7 @@
     "react-hook-form": "^7.43.1",
     "typescript": "4.9.4",
     "vite": "^4.0.4",
+    "vite-tsconfig-paths": "^4.0.5",
     "vitest": "^0.26.3",
     "wouter": "^2.9.0",
     "zod": "3.20.2"

--- a/packages/app-webhooks/vite.config.ts
+++ b/packages/app-webhooks/vite.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import tsconfigPaths from 'vite-tsconfig-paths'
 import { loadEnv } from 'vite'
 
 // https://vitejs.dev/config/
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
     env.PUBLIC_PROJECT_PATH != null ? `/${env.PUBLIC_PROJECT_PATH}` : ''
 
   return {
-    plugins: [react()],
+    plugins: [react(), tsconfigPaths()],
     envPrefix: 'PUBLIC_',
     base: `${basePath}/`,
     build: {
@@ -19,14 +19,6 @@ export default defineConfig(({ mode }) => {
     server: {
       fs: {
         strict: env.ALLOW_LOCAL_PACKAGES === 'true'
-      }
-    },
-    resolve: {
-      alias: {
-        '#components': path.resolve(__dirname, './src/components'),
-        '#pages': path.resolve(__dirname, './src/pages'),
-        '#data': path.resolve(__dirname, './src/data'),
-        '#utils': path.resolve(__dirname, './src/utils')
       }
     },
     test: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,7 @@ importers:
       stylelint-prettier: ^2.0.0
       typescript: 4.9.4
       vite: ^4.0.4
+      vite-tsconfig-paths: ^4.0.5
       vitest: ^0.26.3
       wouter: ^2.9.0
       zod: 3.20.2
@@ -65,6 +66,7 @@ importers:
       react-hook-form: 7.43.1_react@18.2.0
       typescript: 4.9.4
       vite: 4.0.4_@types+node@18.0.1
+      vite-tsconfig-paths: 4.0.5_typescript@4.9.4
       vitest: 0.26.3_jsdom@20.0.3
       wouter: 2.9.1_react@18.2.0
       zod: 3.20.2
@@ -4601,6 +4603,10 @@ packages:
     resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
     dev: true
 
+  /globrex/0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+    dev: false
+
   /gopd/1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -7806,6 +7812,19 @@ packages:
       code-block-writer: 11.0.3
     dev: false
 
+  /tsconfck/2.0.3_typescript@4.9.4:
+    resolution: {integrity: sha512-o3DsPZO1+C98KqHMdAbWs30zpxD30kj8r9OLA4ML1yghx4khNDzaaShNalfluh8ZPPhzKe3qyVCP1HiZszSAsw==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      typescript: 4.9.4
+    dev: false
+
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
@@ -8103,6 +8122,17 @@ packages:
       - '@types/node'
       - rollup
       - supports-color
+    dev: false
+
+  /vite-tsconfig-paths/4.0.5_typescript@4.9.4:
+    resolution: {integrity: sha512-/L/eHwySFYjwxoYt1WRJniuK/jPv+WGwgRGBYx3leciR5wBeqntQpUE6Js6+TJemChc+ter7fDBKieyEWDx4yQ==}
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 2.0.3_typescript@4.9.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: false
 
   /vite/4.0.4_@types+node@18.0.1:


### PR DESCRIPTION
### What does this PR do?
Add `vite-tsconfig-paths` Vite plugin to avoid to manually configure in `vite.config.ts` the same paths defined in `tsconfig.json`.