### PR TITLE
Update tracked `webhooks` and fix `node-ip` vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "devDependencies": {
     "husky": "^9.0.10",
+    "ip": "^2.0.1",
     "lerna": "^8.1.2",
     "lint-staged": "^15.2.2",
     "npm-check-updates": "^16.14.14"

--- a/packages/app/src/data/events.ts
+++ b/packages/app/src/data/events.ts
@@ -3,10 +3,10 @@ import type { ResourceWithEvent } from 'App'
 
 export const webhookEvents: Record<ResourceWithEvent, string[]> = {
   addresses: ['tagged'],
-  authorizations: ['create', 'succeeded'],
+  authorizations: ['create', 'succeeded', 'failed'],
   bundles: ['tagged'],
   buy_x_pay_y_promotions: ['create', 'tagged', 'destroy'],
-  captures: ['create', 'succeeded'],
+  captures: ['create', 'succeeded', 'failed'],
   cleanups: ['create', 'start', 'complete', 'interrupt', 'destroy'],
   coupons: ['tagged'],
   customer_addresses: ['create', 'destroy'],
@@ -96,7 +96,7 @@ export const webhookEvents: Record<ResourceWithEvent, string[]> = {
   price_volume_tiers: ['create', 'destroy'],
   promotions: ['create', 'tagged', 'destroy'],
   recurring_order_copies: ['create', 'destroy', 'start', 'fail', 'complete'],
-  refunds: ['create', 'succeeded'],
+  refunds: ['create', 'succeeded', 'failed'],
   returns: [
     'create',
     'request',
@@ -133,7 +133,7 @@ export const webhookEvents: Record<ResourceWithEvent, string[]> = {
     'destroy'
   ],
   transaction: ['create'],
-  voids: ['create', 'succeeded']
+  voids: ['create', 'succeeded', 'failed']
 }
 
 export function getEventsByResourceType(

--- a/packages/app/src/data/events.ts
+++ b/packages/app/src/data/events.ts
@@ -3,7 +3,7 @@ import type { ResourceWithEvent } from 'App'
 
 export const webhookEvents: Record<ResourceWithEvent, string[]> = {
   addresses: ['tagged'],
-  authorizations: ['create'],
+  authorizations: ['create', 'succeeded'],
   bundles: ['tagged'],
   buy_x_pay_y_promotions: ['create', 'tagged', 'destroy'],
   captures: ['create', 'succeeded'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       husky:
         specifier: ^9.0.10
         version: 9.0.10
+      ip:
+        specifier: ^2.0.1
+        version: 2.0.1
       lerna:
         specifier: ^8.1.2
         version: 8.1.2
@@ -4668,8 +4671,8 @@ packages:
       side-channel: 1.0.4
     dev: true
 
-  /ip@2.0.0:
-    resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
+  /ip@2.0.1:
+    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
     dev: true
 
   /is-array-buffer@3.0.2:
@@ -7581,7 +7584,7 @@ packages:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
     dependencies:
-      ip: 2.0.0
+      ip: 2.0.1
       smart-buffer: 4.2.0
     dev: true
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Updated tracked `webhooks` by adding `authorizations.succeeded` event along with `authorizations.failed`, `captures.failed`,  `voids.failed` and `refunds.failed`
- Fixed `node-ip` vulnerability