### PR TITLE
Add events for `order_subscriptions` last run

### DIFF
--- a/packages/app/src/data/events.ts
+++ b/packages/app/src/data/events.ts
@@ -75,7 +75,9 @@ export const webhookEvents: Record<ResourceWithEvent, string[]> = {
     'destroy',
     'activate',
     'deactivate',
-    'cancel'
+    'cancel',
+    'last_run_failed',
+    'last_run_succeeded'
   ],
   parcels: [
     'create',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added these events for `order_subscriptions`:
- `order_subscriptions.last_run_failed`
- `order_subscriptions.last_run_succeeded`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
